### PR TITLE
Persistence API cleanup

### DIFF
--- a/Good Old Reader 2/ApiManager.m
+++ b/Good Old Reader 2/ApiManager.m
@@ -34,7 +34,7 @@
                  NSDictionary *dataDictionary = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&jsonError];
 
                  NSString *unread = [NSString stringWithFormat:@"%@",dataDictionary[@"max"]];
-                 [PersistenceManager save:unread forKey:@"unreadCount"];
+                 [PersistenceManager save:nil object:unread forKey:@"unreadCount"];
                  [PersistenceManager save:@"group.goodOldReader2" object:unread forKey:@"unreadCount"];
                   
                  completion(unread);

--- a/Good Old Reader 2/FeedTableViewController.m
+++ b/Good Old Reader 2/FeedTableViewController.m
@@ -52,8 +52,10 @@
     qrViewButton.enabled = FALSE;
     qrViewButton.style = UIBarButtonSystemItemEdit;
     
+    id unreadCount = [PersistenceManager load:@"unreadCount" fromGroup:nil];
+    
     // DEMO Logging last sessions unread count
-    NSLog(@"Application closed with %@ unread articles.", [PersistenceManager load:@"unreadCount"]);
+    NSLog(@"Application closed with %@ unread articles.", unreadCount);
     NSLog(@"Application closed with %@ unread articles. (App group)", [PersistenceManager load:@"unreadCount" fromGroup:@"group.goodOldReader2"]);
 }
 

--- a/PersistenceKit/PersistenceKit/PersistenceManager.h
+++ b/PersistenceKit/PersistenceKit/PersistenceManager.h
@@ -10,9 +10,7 @@
 
 @interface PersistenceManager : NSObject
 
-+ (void)save:(id)toSave forKey:(NSString *)key;
 + (void)save:(NSString *)appGroup object:(id)toSave forKey:(NSString *)key;
-+ (id)load:(NSString *)key;
 + (id)load:(NSString *)key fromGroup:(NSString *)appGroup;
 
 @end

--- a/PersistenceKit/PersistenceKit/PersistenceManager.m
+++ b/PersistenceKit/PersistenceKit/PersistenceManager.m
@@ -10,21 +10,10 @@
 
 @implementation PersistenceManager
 
-+ (void)save:(id)toSave forKey:(NSString *)key {
-    NSUserDefaults *sharedDefaults = [NSUserDefaults standardUserDefaults];;
-    [sharedDefaults setObject:toSave forKey:key];
-    [sharedDefaults synchronize];
-}
-
 + (void)save:(NSString *)appGroup object:(id)toSave forKey:(NSString *)key {
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:appGroup];
     [sharedDefaults setObject:toSave forKey:key];
     [sharedDefaults synchronize];
-}
-
-+ (id)load:(NSString *)key {
-    NSUserDefaults *sharedDefaults = [NSUserDefaults standardUserDefaults];;
-    return [sharedDefaults objectForKey:key];
 }
 
 + (id)load:(NSString *)key fromGroup:(NSString *)appGroup {


### PR DESCRIPTION
Check the docs for NSUserDefaults

``` objc
- (nullable instancetype)initWithSuiteName:(nullable NSString *)suitename NS_AVAILABLE(10_9, 7_0) NS_DESIGNATED_INITIALIZER; //nil suite means use the default search list that +standardUserDefaults uses
```

There is no need for separate methods w/ and w/o app group id.
